### PR TITLE
Stream Thumbnails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'uglifier', '>= 1.3.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
 # gem 'mini_racer', platforms: :ruby
 gem "aws-sdk-s3", require: false
+
 gem 'webpacker'
 
 # make sprockets happy even though we don't use this

--- a/app/controllers/active_storage/representations_controller.rb
+++ b/app/controllers/active_storage/representations_controller.rb
@@ -7,9 +7,13 @@ module ActiveStorage
     def show
       expires_in 1.year, public: true
       variant = @blob.representation(params[:variation_key]).processed
-      send_data @blob.service.download(variant.key),
-                type: @blob.content_type || DEFAULT_SEND_FILE_TYPE,
-                disposition: 'inline'
+      send_file_headers!(type: @blob.content_type || DEFAULT_SEND_FILE_TYPE,
+                         disposition: 'inline')
+      self.response_body = Enumerator.new do |f|
+        @blob.service.download(variant.key) do |chunk|
+          f << chunk
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
This causes thumbnails to be *streamed* as opposed to downloaded and then
sent. This is marginally faster and can use a lot less memory for big files.